### PR TITLE
Fix an obvious stupid bug with duplicate rungroup pairs and dicts.

### DIFF
--- a/rungroup-schedule-2020.py
+++ b/rungroup-schedule-2020.py
@@ -66,12 +66,11 @@ raw_double_dippers = {
 
 def compute_choices(rungroups, permutation_selector=default_permutation_selector):
     double_dippers = Counter()
-    double_dippers.update(dict(
-        ((findclass(class1, rungroups), findclass(class2, rungroups)), count) for ((class1, class2), count) in
-        raw_double_dippers.items()))
-    double_dippers.update(dict(
-        ((findclass(class2, rungroups), findclass(class1, rungroups)), count) for ((class1, class2), count) in
-        raw_double_dippers.items()))
+
+    for ((class1, class2), count) in raw_double_dippers.items():
+        double_dippers.update({(findclass(class1, rungroups), findclass(class2, rungroups)): count})
+    for ((class1, class2), count) in raw_double_dippers.items():
+        double_dippers.update({(findclass(class2, rungroups), findclass(class1, rungroups)): count})
 
     permutations_and_scores = []
     for permutation in list(permutations(rungroups)):
@@ -82,8 +81,6 @@ def compute_choices(rungroups, permutation_selector=default_permutation_selector
         overlap = [pair for pair in pairs if pair in double_dippers]
         score = sum(double_dippers.get(pair, 0) for pair in overlap)
         permutations_and_scores += [(permutation, score, overlap)]
-        if len(overlap) == 0:
-            print 'satisifies?', permutation, 'overlap', overlap
 
     min_score = min(score for permutation, score, overlap in permutations_and_scores)
     return [(permutation, score, overlap) for permutation, score, overlap in permutations_and_scores if


### PR DESCRIPTION
We define each pair of classes that had double-dippers, and the number of cars that double-dipped in those two classes last year:

```
    raw_double_dippers = {
        ('sm', 'stl'): 35,
        ('stl', 'bracket'): 17,
        ('fp', 'bracket'): 1,
        ('srf3', 'bracket'): 16,
        ('sm', 'ssm'): 10,
        ('ssm', 'bracket'): 8,
        ('stu', 'bracket'): 3,
        ('ite', 'bracket'): 3,
        ('gt1', 'bracket'): 2,
        ('ssm', 'ita'): 7,
        ('fp', 'ita'): 1,
        ('ep', 'it7'): 1,
        ('ita', 'stl'): 1,
        ('t3', 'ep'): 1,
        ('gtp', 'bspec'): 2,
        ('itb', 'hp'): 1,
        ('sm', 'bracket'): 2,
        ('sm', 'srf3'): 1,
        ('ssm', 'fp'): 1,
        ('ssm', 'its'): 1,
        ('itb', 'bracket'): 1,
        ('sm', 'its'): 1,
    }
```

When we turn that back into pairs of rungroups and their corresponding counts, we get:

```
    (('bigbore', 'bracket'), 3)
    (('srf', 'bracket'), 16)
    (('smallbore', 'it'), 2)
    (('sm', 'bracket'), 2)
    (('smallbore', 'bracket'), 17)
    (('bigbore', 'bracket'), 2)
    (('bigbore', 'smallbore'), 1)
    (('smallbore', 'bigbore'), 1)
    (('bigbore', 'smallbore'), 1)
    (('sm', 'it'), 1)
    (('ssm', 'bracket'), 8)
    (('sm', 'srf'), 1)
    (('smallbore', 'bracket'), 1)
    (('sm', 'ssm'), 10)
    (('it', 'bracket'), 1)
    (('ssm', 'smallbore'), 1)
    (('smallbore', 'bigbore'), 1)
    (('ssm', 'it'), 1)
    (('sm', 'smallbore'), 35)
    (('ssm', 'bigbore'), 7)
    (('it', 'smallbore'), 1)
    (('bigbore', 'bracket'), 3)
```

What I intended to do was to create a python Counter object, which is like a python dict except that it's used to count occurrences of its keys.  Into that, for each pair of rungroups and their counts (e.g., group1, group2, and count) I put them into the Counter with a key of (group1, group2) and a count of count... and with a key of (group2, group1) and the same count, so that no matter how the pairing is expressed, we end up with the same number.

The logic there is fine.  But then I out-clevered myself.

Counters expect to be updated by passing them little dictionaries, with the key as the thing being counted and the value as the count.

I did some fancy-ish python to create the dictionary directly from all the (group1, group2) => count pairs, like so:

```
    double_dippers.update(dict(
        ((findclass(class1, rungroups), findclass(class2, rungroups)), count) for ((class1, class2), count) in
        raw_double_dippers.items()))
    double_dippers.update(dict(
        ((findclass(class2, rungroups), findclass(class1, rungroups)), count) for ((class1, class2), count) in
        raw_double_dippers.items()))
```

but dumbass me didn't think about the fact that if we add the same key twice to that temporary dictionary, the second value will be what's stored.

If you look at that list of rungroup pairs and counts above, you'll see:

```
    (('smallbore', 'bracket'), 17)

    ...

    (('smallbore', 'bracket'), 1)
```

because we had 17 stl/bracket and 1 fp/bracket.

So that second smallbore/bracket count was the one we recorded, which of course threw everything off.

Making the code actually iterate across all the possibilities, and update the counter piece by piece, fixed the bug:

```
    for ((class1, class2), count) in raw_double_dippers.items():
        double_dippers.update({(findclass(class1, rungroups), findclass(class2, rungroups)): count})
    for ((class1, class2), count) in raw_double_dippers.items():
        double_dippers.update({(findclass(class2, rungroups), findclass(class1, rungroups)): count})
```

I am guessing that either we lucked out last year and didn't run into this type of issue, or we had this issue then but it just wasn't really obvious and no one complained about it.